### PR TITLE
omit border for 3~5 layers

### DIFF
--- a/ccv/cwc-bench.c
+++ b/ccv/cwc-bench.c
@@ -94,7 +94,7 @@ int main(int argc, char** argv)
 				.convolutional = {
 					.count = 128,
 					.strides = 1,
-					.border = 1,
+					.border = 0,
 					.rows = 9,
 					.cols = 9,
 					.channels = 128,
@@ -119,7 +119,7 @@ int main(int argc, char** argv)
 				.convolutional = {
 					.count = 128,
 					.strides = 1,
-					.border = 1,
+					.border = 0,
 					.rows = 7,
 					.cols = 7,
 					.channels = 128,
@@ -144,7 +144,7 @@ int main(int argc, char** argv)
 				.convolutional = {
 					.count = 384,
 					.strides = 1,
-					.border = 1,
+					.border = 0,
 					.rows = 3,
 					.cols = 3,
 					.channels = 384,


### PR DESCRIPTION
In previous commit, I added border for 3 to 5 layers computation, it seems other tests don't have border specified, not sure if that would impact their numbers. For ccv, this is how it works:

(input width + border \* 2 - kernel width - 1 + strides) / strides + 1 == output width
