### PR TITLE
Update Theano benchmark instructions

### DIFF
--- a/theano/README.md
+++ b/theano/README.md
@@ -2,7 +2,6 @@ Install Theano:
 ```
 git clone git://github.com/Theano/Theano.git
 cd Theano
-git pull https://github.com/f0k/Theano corrmm-faster-fullconv
 sudo python setup.py develop
 ```
 


### PR DESCRIPTION
Since a while, the `git pull https://github.com/f0k/Theano corrmm-faster-fullconv` line is no longer needed. (And not working either.)
