### PR TITLE
Theano benchmark: Removed two lines resetting the compile mode

### DIFF
--- a/theano/README.md
+++ b/theano/README.md
@@ -38,5 +38,5 @@ sudo python setup.py install
 
 Launch the script:
 ```
-SKIP=legacy THEANO_FLAGS=floatX=float32 python pylearn2_benchmark.py
+SKIP=legacy python pylearn2_benchmark.py
 ```

--- a/theano/pylearn2_benchmark.py
+++ b/theano/pylearn2_benchmark.py
@@ -3,6 +3,12 @@ import sys
 import numpy as np
 import math
 
+import theano
+if not theano.config.device.startswith('gpu'):
+    import theano.sandbox.cuda
+    theano.sandbox.cuda.use('gpu')
+theano.config.floatX = 'float32'
+
 try:
     import theano.misc.pycuda_init
     import pycuda.driver
@@ -197,7 +203,7 @@ for run in runs:
     print ''
     print 'CONFIG: input =', ni, 'x', iw, 'x', ih, '* ker =', ni, 'x', no, 'x', kw, 'x', kh, '( bs =', bs, ', stride =', dw, ')'
     ops = 2  # ops per point
-    mode = theano.compile.get_default_mode().including('gpu')
+    mode = theano.compile.get_default_mode()
 
     # benchmark Theano legacy convolution
     # Mimic THEANO_FLAGS=optimizer_excluding=conv_gemm:conv_dnn


### PR DESCRIPTION
The Theano benchmark code had two forgotten lines resetting the compile mode halfway through the benchmark so everything run afterwards wouldn't use the GPU by default. Fixed by this PR.
