### PR TITLE
Use Caffe master branch instead of dev

### DIFF
--- a/caffe/install.sh
+++ b/caffe/install.sh
@@ -1,6 +1,5 @@
 git clone https://github.com/BVLC/caffe.git
 cd caffe
-git checkout dev
 
 # Dependencies
 sudo apt-get install -y libprotobuf-dev libleveldb-dev libsnappy-dev libopencv-dev libboost-all-dev libhdf5-serial-dev 


### PR DESCRIPTION
Caffe dev branch is deprecated and deleted. "git checkout dev" fails.
https://github.com/BVLC/caffe/issues/1943