### PR TITLE
Adding control flow to avoid memcpy

### DIFF
--- a/tensorflow/benchmark_alexnet.py
+++ b/tensorflow/benchmark_alexnet.py
@@ -95,9 +95,11 @@ def time_tensorflow_run(session, target, info_string):
   num_steps_burn_in = 10
   total_duration = 0.0
   total_duration_squared = 0.0
+  if not isinstance(target, list):
+    target = [target]
   for i in xrange(FLAGS.num_batches + num_steps_burn_in):
     start_time = time.time()
-    _ = session.run(target)
+    _ = session.run(tf.group(*target))
     duration = time.time() - start_time
     if i > num_steps_burn_in:
       if not i % 10:

--- a/tensorflow/benchmark_googlenet.py
+++ b/tensorflow/benchmark_googlenet.py
@@ -132,9 +132,11 @@ def time_tensorflow_run(session, target, info_string):
   num_steps_burn_in = 10
   total_duration = 0.0
   total_duration_squared = 0.0
+  if not isinstance(target, list):
+    target = [target]
   for i in xrange(FLAGS.num_batches + num_steps_burn_in):
     start_time = time.time()
-    _ = session.run(target)
+    _ = session.run(tf.group(*target))
     duration = time.time() - start_time
     if i > num_steps_burn_in:
       if not i % 10:

--- a/tensorflow/benchmark_overfeat.py
+++ b/tensorflow/benchmark_overfeat.py
@@ -95,9 +95,11 @@ def time_tensorflow_run(session, target, info_string):
   num_steps_burn_in = 10
   total_duration = 0.0
   total_duration_squared = 0.0
+  if not isinstance(target, list):
+    target = [target]
   for i in xrange(FLAGS.num_batches + num_steps_burn_in):
     start_time = time.time()
-    _ = session.run(target)
+    _ = session.run(tf.group(*target))
     duration = time.time() - start_time
     if i > num_steps_burn_in:
       if not i % 10:

--- a/tensorflow/benchmark_vgg.py
+++ b/tensorflow/benchmark_vgg.py
@@ -101,9 +101,11 @@ def time_tensorflow_run(session, target, info_string):
   num_steps_burn_in = 10
   total_duration = 0.0
   total_duration_squared = 0.0
+  if not isinstance(target, list):
+    target = [target]
   for i in xrange(FLAGS.num_batches + num_steps_burn_in):
     start_time = time.time()
-    _ = session.run(target)
+    _ = session.run(tf.group(*target))
     duration = time.time() - start_time
     if i > num_steps_burn_in:
       if not i % 10:


### PR DESCRIPTION
Hi Soumith - sorry to add to your already busy schedule. Could you check if the following change addresses part of the speed issue? I should have run it on my machine but I have a K40, so the numbers may not be comparable.

The background story: for TensorFlow's session.run(target), it also automatically fetches the contents of the target from the TensorFlow backend into Python. If the targets are on GPU, an implicit MemcpyDtoH is called, and this may cause unnecessary delays. In practice, since the SGD will always be on the GPU, the fetching is not needed.

We realized that this side effect slipped off our notice because convolutional layers have very few parameters and the MemcpyDtoH latency got overlooked.

Again, thanks a lot for maintaining the benchmarking results!