### PR TITLE
TensorFlow benchmark fix: Group the target ops outside of the timing

### DIFF
--- a/tensorflow/benchmark_alexnet.py
+++ b/tensorflow/benchmark_alexnet.py
@@ -119,9 +119,10 @@ def time_tensorflow_run(session, target, info_string):
   total_duration_squared = 0.0
   if not isinstance(target, list):
     target = [target]
+  target_op = tf.group(*target)
   for i in xrange(FLAGS.num_batches + num_steps_burn_in):
     start_time = time.time()
-    _ = session.run(tf.group(*target))
+    _ = session.run(target_op)
     duration = time.time() - start_time
     if i > num_steps_burn_in:
       if not i % 10:

--- a/tensorflow/benchmark_googlenet.py
+++ b/tensorflow/benchmark_googlenet.py
@@ -166,9 +166,10 @@ def time_tensorflow_run(session, target, info_string):
   total_duration_squared = 0.0
   if not isinstance(target, list):
     target = [target]
+  target_op = tf.group(*target)
   for i in xrange(FLAGS.num_batches + num_steps_burn_in):
     start_time = time.time()
-    _ = session.run(tf.group(*target))
+    _ = session.run(target_op)
     duration = time.time() - start_time
     if i > num_steps_burn_in:
       if not i % 10:

--- a/tensorflow/benchmark_overfeat.py
+++ b/tensorflow/benchmark_overfeat.py
@@ -119,9 +119,10 @@ def time_tensorflow_run(session, target, info_string):
   total_duration_squared = 0.0
   if not isinstance(target, list):
     target = [target]
+  target_op = tf.group(*target)
   for i in xrange(FLAGS.num_batches + num_steps_burn_in):
     start_time = time.time()
-    _ = session.run(tf.group(*target))
+    _ = session.run(target_op)
     duration = time.time() - start_time
     if i > num_steps_burn_in:
       if not i % 10:

--- a/tensorflow/benchmark_vgg.py
+++ b/tensorflow/benchmark_vgg.py
@@ -125,9 +125,10 @@ def time_tensorflow_run(session, target, info_string):
   total_duration_squared = 0.0
   if not isinstance(target, list):
     target = [target]
+  target_op = tf.group(*target)
   for i in xrange(FLAGS.num_batches + num_steps_burn_in):
     start_time = time.time()
-    _ = session.run(tf.group(*target))
+    _ = session.run(target_op)
     duration = time.time() - start_time
     if i > num_steps_burn_in:
       if not i % 10:


### PR DESCRIPTION
loop.

Otherwise, each iteration we add another op to the graph, erasing the
graph cache.

H/T to @dvyukov and @jeffreyadean for finding this.

With this change on my TitanX and cudnnv4:

- AlexNet goes from 29/90ms fwd/total to 26/81ms.
- Googlenet goes from 150/485ms fwd/total to 133/465ms.
- The other two didn't change for me

In general when benchmarking TF, we should not be adding ops to the graph in the
timing loop, so even if this doesn't help in all cases, it's still the right pattern to demonstrate.