### PR TITLE
[torch7] Fix googlenet first layer gradInput

### DIFF
--- a/torch7/imagenet_winners/googlenet.lua
+++ b/torch7/imagenet_winners/googlenet.lua
@@ -56,6 +56,7 @@ local function googlenet(lib)
    -- model:add(nn.Dropout(0.4))
    model:add(nn.Linear(1024,1000)):add(nn.ReLU(true))
    -- model:add(nn.LogSoftMax())
+   model:get(1).gradInput = nil
    return model,'GoogleNet', {128,3,224,224}
 end
 


### PR DESCRIPTION
On my machine this costs 15ms overhead in backprop. Alexnet, VGG and Overfeat have this fix, only googlenet hasn't.

before:
```
Running on device: GeForce GTX TITAN X
ModelType: GoogleNet	Kernels: cudnn	Input shape: 128x3x224x224
cudnn                                   :updateOutput():     137.11
cudnn                                :updateGradInput():     197.32
cudnn                              :accGradParameters():     148.47
cudnn                                          :Forward:     137.11
cudnn                                         :Backward:     345.79
cudnn                                            :TOTAL:     482.90
```

after:
```
Running on device: GeForce GTX TITAN X
ModelType: GoogleNet	Kernels: cudnn	Input shape: 128x3x224x224
cudnn                                   :updateOutput():     136.59
cudnn                                :updateGradInput():     179.40
cudnn                              :accGradParameters():     149.36
cudnn                                          :Forward:     136.59
cudnn                                         :Backward:     328.76
cudnn                                            :TOTAL:     465.34
```