### PR TITLE
Fix missing brackets in chainer's train_imagenet.py

### DIFF
--- a/chainer/train_imagenet.py
+++ b/chainer/train_imagenet.py
@@ -98,9 +98,9 @@ def train_loop():
         # print "Optimizer update time elapsed:", time_, " ms"
 
         del loss, accuracy
-    print "Average Forward:  ", total_forward  / niter-1 , " ms"
-    print "Average Backward: ", total_backward / niter-1 , " ms"
-    print "Average Total:    ", (total_forward + total_backward) / niter-1 , " ms"
+    print "Average Forward:  ", total_forward  / (niter-1), " ms"
+    print "Average Backward: ", total_backward / (niter-1), " ms"
+    print "Average Total:    ", (total_forward + total_backward) / (niter-1), " ms"
     print ""
 
 train_loop()


### PR DESCRIPTION
The results of chainer are about 10% faster than the correct values.

uncomment: print "Forward step time elapsed:", time_, " ms"

    Forward step time elapsed: 573.047119141  ms  # exclude
    Forward step time elapsed: 117.443939209  ms
    Forward step time elapsed: 117.843490601  ms
    Forward step time elapsed: 116.918205261  ms
    Forward step time elapsed: 117.250846863  ms
    Forward step time elapsed: 117.109214783  ms
    Forward step time elapsed: 117.274017334  ms
    Forward step time elapsed: 117.212028503  ms
    Forward step time elapsed: 117.451164246  ms
    Forward step time elapsed: 117.719741821  ms

before:

    ./train_imagenet.py --arch alexnet --batchsize 128 | tee out_alexnet_test1.log
    alexnet
    Average Forward:   104.622264862  ms
    Average Backward:  254.636958599  ms
    Average Total:     360.259223461  ms

after:

    ./train_imagenet.py --arch alexnet --batchsize 128 | tee out_alexnet_test2.log
    Average Forward:   117.576182048  ms
    Average Backward:  284.237788094  ms
    Average Total:     401.813970142  ms